### PR TITLE
[1.0.0] 최근 검색어를 저장하는 로직을 추가합니다.

### DIFF
--- a/KuringLite.xcodeproj/project.pbxproj
+++ b/KuringLite.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		A9F83783284C96880045FDBD /* FeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F83781284C96880045FDBD /* FeedbackState.swift */; };
 		B11BA8872850742300C82836 /* AppStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11BA8862850742300C82836 /* AppStorageManager.swift */; };
 		B11BA88A285074A900C82836 /* StringSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11BA889285074A900C82836 /* StringSet.swift */; };
+		B11BA88D285085BD00C82836 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = B11BA88C285085BD00C82836 /* Collections */; };
+		B11BA88F285085BD00C82836 /* DequeModule in Frameworks */ = {isa = PBXBuildFile; productRef = B11BA88E285085BD00C82836 /* DequeModule */; };
+		B11BA891285085BD00C82836 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = B11BA890285085BD00C82836 /* OrderedCollections */; };
 		B1C641CB284F518500473184 /* SearchedRecentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C641CA284F518500473184 /* SearchedRecentView.swift */; };
 /* End PBXBuildFile section */
 
@@ -85,8 +88,11 @@
 			files = (
 				A983BAD1284BB0C800B96FF1 /* KuringCommons in Frameworks */,
 				A983BAE4284BBDDA00B96FF1 /* Starscream in Frameworks */,
+				B11BA88D285085BD00C82836 /* Collections in Frameworks */,
 				A983BAF2284BCBCC00B96FF1 /* Lottie in Frameworks */,
 				A95125AB284CA6770072EB8E /* KuringSDK in Frameworks */,
+				B11BA891285085BD00C82836 /* OrderedCollections in Frameworks */,
+				B11BA88F285085BD00C82836 /* DequeModule in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -320,6 +326,9 @@
 				A983BAE3284BBDDA00B96FF1 /* Starscream */,
 				A983BAF1284BCBCC00B96FF1 /* Lottie */,
 				A95125AA284CA6770072EB8E /* KuringSDK */,
+				B11BA88C285085BD00C82836 /* Collections */,
+				B11BA88E285085BD00C82836 /* DequeModule */,
+				B11BA890285085BD00C82836 /* OrderedCollections */,
 			);
 			productName = KuringLite;
 			productReference = A983BABE284BB08F00B96FF1 /* 쿠링 Lite.app */;
@@ -354,6 +363,7 @@
 				A983BAE2284BBDDA00B96FF1 /* XCRemoteSwiftPackageReference "Starscream" */,
 				A983BAF0284BCBCC00B96FF1 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				A95125A9284CA6770072EB8E /* XCRemoteSwiftPackageReference "kuring-sdk-ios-spm" */,
+				B11BA88B285085BD00C82836 /* XCRemoteSwiftPackageReference "swift-collections" */,
 			);
 			productRefGroup = A983BABF284BB08F00B96FF1 /* Products */;
 			projectDirPath = "";
@@ -645,6 +655,14 @@
 				minimumVersion = 3.0.0;
 			};
 		};
+		B11BA88B285085BD00C82836 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-collections.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -667,6 +685,21 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A983BAF0284BCBCC00B96FF1 /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
+		};
+		B11BA88C285085BD00C82836 /* Collections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B11BA88B285085BD00C82836 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = Collections;
+		};
+		B11BA88E285085BD00C82836 /* DequeModule */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B11BA88B285085BD00C82836 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = DequeModule;
+		};
+		B11BA890285085BD00C82836 /* OrderedCollections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B11BA88B285085BD00C82836 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = OrderedCollections;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/KuringLite.xcodeproj/project.pbxproj
+++ b/KuringLite.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		A9F83777284C8B930045FDBD /* SearchedStaffRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F83776284C8B930045FDBD /* SearchedStaffRow.swift */; };
 		A9F83779284C93A60045FDBD /* SwiftPackageRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F83778284C93A60045FDBD /* SwiftPackageRow.swift */; };
 		A9F83783284C96880045FDBD /* FeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F83781284C96880045FDBD /* FeedbackState.swift */; };
+		B11BA8872850742300C82836 /* AppStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11BA8862850742300C82836 /* AppStorageManager.swift */; };
+		B11BA88A285074A900C82836 /* StringSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11BA889285074A900C82836 /* StringSet.swift */; };
+		B1C641CB284F518500473184 /* SearchedRecentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C641CA284F518500473184 /* SearchedRecentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -70,6 +73,9 @@
 		A9F83776284C8B930045FDBD /* SearchedStaffRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchedStaffRow.swift; sourceTree = "<group>"; };
 		A9F83778284C93A60045FDBD /* SwiftPackageRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftPackageRow.swift; sourceTree = "<group>"; };
 		A9F83781284C96880045FDBD /* FeedbackState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedbackState.swift; sourceTree = "<group>"; };
+		B11BA8862850742300C82836 /* AppStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorageManager.swift; sourceTree = "<group>"; };
+		B11BA889285074A900C82836 /* StringSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringSet.swift; sourceTree = "<group>"; };
+		B1C641CA284F518500473184 /* SearchedRecentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchedRecentView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,6 +144,7 @@
 				A9F83774284C8B870045FDBD /* SearchedNoticeRow.swift */,
 				A9F83776284C8B930045FDBD /* SearchedStaffRow.swift */,
 				A9F83770284C881C0045FDBD /* SearchTypeColumn.swift */,
+				B1C641CA284F518500473184 /* SearchedRecentView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -195,6 +202,7 @@
 				A983BAD7284BB53C00B96FF1 /* Search */,
 				A983BADD284BB58200B96FF1 /* Settings */,
 				A9F8377F284C96880045FDBD /* Feedback */,
+				B11BA8882850742A00C82836 /* Manager */,
 				A983BAF5284BCC8300B96FF1 /* Commons */,
 				A983BAF8284BCD4100B96FF1 /* Extensions */,
 				A983BAC5284BB08F00B96FF1 /* Assets.xcassets */,
@@ -251,6 +259,7 @@
 		A983BAF5284BCC8300B96FF1 /* Commons */ = {
 			isa = PBXGroup;
 			children = (
+				B11BA889285074A900C82836 /* StringSet.swift */,
 				A983BAEE284BCB9B00B96FF1 /* LottieView.swift */,
 				A983BAF3284BCC7700B96FF1 /* lottieLoading.json */,
 			);
@@ -280,6 +289,14 @@
 				A95125B5284D00520072EB8E /* View */,
 			);
 			path = Feedback;
+			sourceTree = "<group>";
+		};
+		B11BA8882850742A00C82836 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				B11BA8862850742300C82836 /* AppStorageManager.swift */,
+			);
+			path = Manager;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -370,8 +387,10 @@
 				A983BADC284BB57B00B96FF1 /* SettingsView.swift in Sources */,
 				A983BAE6284BC16D00B96FF1 /* SubscriptionSelection.swift in Sources */,
 				A983BAFA284BCDB700B96FF1 /* NoticeType.KuringLite.swift in Sources */,
+				B11BA8872850742300C82836 /* AppStorageManager.swift in Sources */,
 				A983BAED284BCB1F00B96FF1 /* NoticeTypeColumn.swift in Sources */,
 				A95125AD284CF94F0072EB8E /* KuringLite.docc in Sources */,
+				B11BA88A285074A900C82836 /* StringSet.swift in Sources */,
 				A983BAC4284BB08F00B96FF1 /* ContentView.swift in Sources */,
 				A983BAE9284BC9CF00B96FF1 /* NoticeRow.swift in Sources */,
 				A9F83773284C8B730045FDBD /* SearchedResultList.swift in Sources */,
@@ -389,6 +408,7 @@
 				A983BADF284BB78700B96FF1 /* SubscriptionView.swift in Sources */,
 				A983BAEF284BCB9B00B96FF1 /* LottieView.swift in Sources */,
 				A9F83775284C8B870045FDBD /* SearchedNoticeRow.swift in Sources */,
+				B1C641CB284F518500473184 /* SearchedRecentView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/KuringLite/ContentView.swift
+++ b/KuringLite/ContentView.swift
@@ -51,6 +51,7 @@ struct ContentView: View {
                         
                         NavigationLink {
                             SearchView()
+                                .environmentObject(SearchEngine())
                         } label: {
                             Image(systemName: "magnifyingglass")
                         }

--- a/KuringLite/Manager/AppStorageManager.swift
+++ b/KuringLite/Manager/AppStorageManager.swift
@@ -13,5 +13,5 @@ class AppStorageManager {
     private init() { }
     
     @AppStorage(StringSet.recentSearch)
-    var recentSearch: [String] = []
+    var recentSearch: [String] = UserDefaults.standard.array(forKey: StringSet.recentSearch) as? [String] ?? []
 }

--- a/KuringLite/Manager/AppStorageManager.swift
+++ b/KuringLite/Manager/AppStorageManager.swift
@@ -1,0 +1,18 @@
+//
+//  AppStorageManager.swift
+//  KuringLite
+//
+//  Created by Hamlit Jason on 2022/06/08.
+//
+
+import Foundation
+import SwiftUI
+
+class AppStorageManager {
+    static let shared = AppStorageManager()
+    
+    private init() { }
+    
+    @AppStorage(StringSet.recentSearch)
+    var recentSearch: [String] = []
+}

--- a/KuringLite/Manager/AppStorageManager.swift
+++ b/KuringLite/Manager/AppStorageManager.swift
@@ -5,7 +5,6 @@
 //  Created by Hamlit Jason on 2022/06/08.
 //
 
-import Foundation
 import SwiftUI
 
 class AppStorageManager {

--- a/KuringLite/Search/DataModel/SearchEngine.swift
+++ b/KuringLite/Search/DataModel/SearchEngine.swift
@@ -35,6 +35,8 @@ import KuringCommons
 
 /// 쿠링의 검색 관련 데이터를 관리하는 검색엔진 모델
 class SearchEngine: ObservableObject {
+    
+    @Published var inputText: String = ""
     @Published var searchText: String = ""
     
     @Published var currentType: Searcher.SearchType = .notice {

--- a/KuringLite/Search/DataModel/SearchEngine.swift
+++ b/KuringLite/Search/DataModel/SearchEngine.swift
@@ -35,9 +35,15 @@ import KuringCommons
 
 /// 쿠링의 검색 관련 데이터를 관리하는 검색엔진 모델
 class SearchEngine: ObservableObject {
+    @Published var recentText: [String] = AppStorageManager.shared.recentSearch
     
     @Published var inputText: String = ""
-    @Published var searchText: String = ""
+    @Published var searchText: String = "" {
+        didSet {
+            recentText.append(searchText)
+            Logger.debug("AppStorage: \(recentText)", action: nil)
+        }
+    }
     
     @Published var currentType: Searcher.SearchType = .notice {
         didSet {

--- a/KuringLite/Search/DataModel/SearchEngine.swift
+++ b/KuringLite/Search/DataModel/SearchEngine.swift
@@ -32,6 +32,7 @@
 import SwiftUI
 import KuringSDK
 import KuringCommons
+import OrderedCollections
 
 /// 쿠링의 검색 관련 데이터를 관리하는 검색엔진 모델
 class SearchEngine: ObservableObject {

--- a/KuringLite/Search/View/SearchTypeColumn.swift
+++ b/KuringLite/Search/View/SearchTypeColumn.swift
@@ -35,7 +35,7 @@ import KuringCommons
 
 /// 검색타입 (공지, 교직원) 에 대하여 하나의 검색타입을 나타내는 뷰
 struct SearchTypeColumn: View {
-    @ObservedObject var engine: SearchEngine
+    @EnvironmentObject var engine: SearchEngine
     let searchType: Searcher.SearchType
     
     var body: some View {

--- a/KuringLite/Search/View/SearchView.swift
+++ b/KuringLite/Search/View/SearchView.swift
@@ -56,10 +56,13 @@ struct SearchView: View {
                 RoundedRectangle(cornerRadius: 20)
                     .stroke(ColorSet.green.color, lineWidth: 1)
             )
-            .padding(16)
+            .padding([.horizontal, .top], 16)
+            .padding(.bottom, 10)
             
-            SearchedRecentList()
-                .frame(maxWidth: .infinity, minHeight: 30)
+            if !engine.recentText.isEmpty {            
+                SearchedRecentList()
+                    .padding(.bottom, 10)
+            }
             
             ScrollView(showsIndicators: false) {
                 LazyVStack {

--- a/KuringLite/Search/View/SearchView.swift
+++ b/KuringLite/Search/View/SearchView.swift
@@ -46,6 +46,7 @@ struct SearchView: View {
                 TextField("", text: $engine.inputText, onCommit: {
                     Logger.debug("🐻 키보드 엔터 입력이 들어왔어요")
                     engine.searchText = engine.inputText
+                    
                 })
             }
             .padding(.horizontal, 20)
@@ -55,6 +56,9 @@ struct SearchView: View {
                     .stroke(ColorSet.green.color, lineWidth: 1)
             )
             .padding(16)
+            
+            SearchedRecentList(recentList: $engine.recentText)
+                .frame(maxWidth: .infinity, minHeight: 30)
             
             ScrollView(showsIndicators: false) {
                 LazyVStack {

--- a/KuringLite/Search/View/SearchView.swift
+++ b/KuringLite/Search/View/SearchView.swift
@@ -7,19 +7,19 @@
 
 /**
  MIT License
-
+ 
  Copyright (c) 2022 쿠링
-
+ 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
-
+ 
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
-
+ 
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -43,7 +43,10 @@ struct SearchView: View {
                 Image(systemName: "magnifyingglass")
                     .foregroundColor(ColorSet.green.color)
                 
-                TextField("검색어를 입력해주세요", text: $engine.searchText)
+                TextField("", text: $engine.inputText, onCommit: {
+                    Logger.debug("🐻 키보드 엔터 입력이 들어왔어요")
+                    engine.searchText = engine.inputText
+                })
             }
             .padding(.horizontal, 20)
             .frame(height: 40)

--- a/KuringLite/Search/View/SearchView.swift
+++ b/KuringLite/Search/View/SearchView.swift
@@ -37,6 +37,7 @@ import KuringCommons
 struct SearchView: View {
     @EnvironmentObject var engine: SearchEngine
     
+    
     var body: some View {
         VStack {
             HStack {

--- a/KuringLite/Search/View/SearchView.swift
+++ b/KuringLite/Search/View/SearchView.swift
@@ -35,7 +35,7 @@ import KuringCommons
 
 /// 검색화면을 나타내는 뷰
 struct SearchView: View {
-    @StateObject private var engine = SearchEngine()
+    @EnvironmentObject var engine: SearchEngine
     
     var body: some View {
         VStack {
@@ -57,7 +57,7 @@ struct SearchView: View {
             )
             .padding(16)
             
-            SearchedRecentList(recentList: $engine.recentText, searchText: $engine.searchText)
+            SearchedRecentList()
                 .frame(maxWidth: .infinity, minHeight: 30)
             
             ScrollView(showsIndicators: false) {
@@ -65,13 +65,12 @@ struct SearchView: View {
                     HStack(spacing: 10) {
                         ForEach(Searcher.SearchType.allCases, id: \.self) {
                             SearchTypeColumn(
-                                engine: engine,
                                 searchType: $0
                             )
                         }
                     }
                     
-                    SearchedResultList(engine: engine)
+                    SearchedResultList()
                 }
             }
         }

--- a/KuringLite/Search/View/SearchView.swift
+++ b/KuringLite/Search/View/SearchView.swift
@@ -57,7 +57,7 @@ struct SearchView: View {
             )
             .padding(16)
             
-            SearchedRecentList(recentList: $engine.recentText)
+            SearchedRecentList(recentList: $engine.recentText, searchText: $engine.searchText)
                 .frame(maxWidth: .infinity, minHeight: 30)
             
             ScrollView(showsIndicators: false) {

--- a/KuringLite/Search/View/SearchView.swift
+++ b/KuringLite/Search/View/SearchView.swift
@@ -45,6 +45,7 @@ struct SearchView: View {
                 
                 TextField("", text: $engine.inputText, onCommit: {
                     Logger.debug("🐻 키보드 엔터 입력이 들어왔어요")
+                    engine.recentText.removeAll { $0 == engine.inputText }
                     engine.searchText = engine.inputText
                     
                 })

--- a/KuringLite/Search/View/SearchedRecentView.swift
+++ b/KuringLite/Search/View/SearchedRecentView.swift
@@ -45,6 +45,7 @@ struct SearchedRecentList: View {
     
     private func search(_ text: String) {
         engine.searchText = text
+        engine.inputText = text
     }
 }
 

--- a/KuringLite/Search/View/SearchedRecentView.swift
+++ b/KuringLite/Search/View/SearchedRecentView.swift
@@ -1,0 +1,52 @@
+//
+//  SearchedRecentList.swift
+//  KuringLite
+//
+//  Created by Hamlit Jason on 2022/06/07.
+//
+
+import SwiftUI
+import KuringCommons
+
+struct SearchedRecentList: View {
+    
+    @Binding var recentList: [String]
+    init(recentList: Binding<[String]>) {
+        _recentList = recentList
+    }
+    
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack {
+                ForEach(recentList, id: \.self) { text in
+                    
+                    HStack(spacing: 5) {
+                        Text("\(text)")
+                            .foregroundColor(ColorSet.Label.secondary.color)
+                            .padding(.leading, 10)
+                        
+                        Button {
+                            // remove Action
+                        } label: {
+                            Image(systemName: "xmark")
+                                .foregroundColor(ColorSet.secondaryGray.color)
+                        }
+
+                    }
+                    .background(
+                        RoundedRectangle(cornerRadius: 10.0)
+                            .foregroundColor(ColorSet.secondaryGreen.color)
+                        
+                    )
+                }
+            }
+            .padding(.leading, 20)
+        }
+    }
+}
+
+//struct SearchedRecentList_Previews: PreviewProvider {
+//    static var previews: some View {
+//        SearchedRecentList()
+//    }
+//}

--- a/KuringLite/Search/View/SearchedRecentView.swift
+++ b/KuringLite/Search/View/SearchedRecentView.swift
@@ -44,6 +44,8 @@ struct SearchedRecentList: View {
     }
     
     private func search(_ text: String) {
+        engine.recentText.removeAll { String($0) == text }
+        
         engine.searchText = text
         engine.inputText = text
     }

--- a/KuringLite/Search/View/SearchedRecentView.swift
+++ b/KuringLite/Search/View/SearchedRecentView.swift
@@ -25,7 +25,7 @@ struct SearchedRecentList: View {
                             }
                         
                         Button {
-                            // remove Action
+                            engine.recentText.removeAll { String($0) == text }
                         } label: {
                             Image(systemName: "xmark")
                                 .foregroundColor(ColorSet.secondaryGray.color)

--- a/KuringLite/Search/View/SearchedRecentView.swift
+++ b/KuringLite/Search/View/SearchedRecentView.swift
@@ -9,19 +9,12 @@ import SwiftUI
 import KuringCommons
 
 struct SearchedRecentList: View {
-    
-    @Binding var recentList: [String]
-    @Binding var searchText: String
-    
-    init(recentList: Binding<[String]>, searchText: Binding<String>) {
-        _recentList = recentList
-        _searchText = searchText
-    }
+    @EnvironmentObject private var engine: SearchEngine
     
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
-                ForEach(recentList, id: \.self) { text in
+                ForEach(engine.recentText, id: \.self) { text in
                     
                     HStack(spacing: 5) {
                         Text("\(text)")
@@ -51,7 +44,7 @@ struct SearchedRecentList: View {
     }
     
     private func search(_ text: String) {
-        searchText = text
+        engine.searchText = text
     }
 }
 

--- a/KuringLite/Search/View/SearchedRecentView.swift
+++ b/KuringLite/Search/View/SearchedRecentView.swift
@@ -11,8 +11,11 @@ import KuringCommons
 struct SearchedRecentList: View {
     
     @Binding var recentList: [String]
-    init(recentList: Binding<[String]>) {
+    @Binding var searchText: String
+    
+    init(recentList: Binding<[String]>, searchText: Binding<String>) {
         _recentList = recentList
+        _searchText = searchText
     }
     
     var body: some View {
@@ -24,6 +27,9 @@ struct SearchedRecentList: View {
                         Text("\(text)")
                             .foregroundColor(ColorSet.Label.secondary.color)
                             .padding(.leading, 10)
+                            .onTapGesture {
+                                search(text)
+                            }
                         
                         Button {
                             // remove Action
@@ -42,6 +48,10 @@ struct SearchedRecentList: View {
             }
             .padding(.leading, 20)
         }
+    }
+    
+    private func search(_ text: String) {
+        searchText = text
     }
 }
 

--- a/KuringLite/Search/View/SearchedRecentView.swift
+++ b/KuringLite/Search/View/SearchedRecentView.swift
@@ -18,6 +18,7 @@ struct SearchedRecentList: View {
                     
                     HStack(spacing: 5) {
                         Text("\(text)")
+                            .font(.system(size: 16))
                             .foregroundColor(ColorSet.Label.secondary.color)
                             .padding(.leading, 10)
                             .onTapGesture {
@@ -29,6 +30,7 @@ struct SearchedRecentList: View {
                         } label: {
                             Image(systemName: "xmark")
                                 .foregroundColor(ColorSet.secondaryGray.color)
+                                
                         }
 
                     }

--- a/KuringLite/Search/View/SearchedRecentView.swift
+++ b/KuringLite/Search/View/SearchedRecentView.swift
@@ -14,7 +14,7 @@ struct SearchedRecentList: View {
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
-                ForEach(engine.recentText, id: \.self) { text in
+                ForEach(engine.recentText.reversed(), id: \.self) { text in
                     
                     HStack(spacing: 5) {
                         Text("\(text)")

--- a/KuringLite/Search/View/SearchedResultList.swift
+++ b/KuringLite/Search/View/SearchedResultList.swift
@@ -33,7 +33,7 @@ import SwiftUI
 
 /// 검색 결과들을 리스트 형태로 보여주는 뷰
 struct SearchedResultList: View {
-    @ObservedObject var engine: SearchEngine
+    @EnvironmentObject var engine: SearchEngine
     
     var body: some View {
         LazyVStack(alignment: .leading) {


### PR DESCRIPTION
최근 검색어를 저장하는 로직을 추가했습니다.

검색어는 최근 검색어가 제일 앞쪽에 위치합니다.
이미 존재하는 검색어는 자동으로 사라지고, 좌우로 스크롤이 가능하게 만들었습니다.
또한 검색어 선택시, 자동으로 선택하여 검색을 수행합니다.
검색어 옆에 X버튼을 클릭하면 최근 검색어에서 사라집니다.